### PR TITLE
disable strictPropertyInitialization in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "strictBindCallApply": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "strictPropertyInitialization": false
   }
 }


### PR DESCRIPTION
TypeORM entities and NestJS DTOs use decorators for property initialization, so TypeScript's strictPropertyInitialization check is a false positive in this project. Setting it explicitly to false prevents IDE errors without affecting runtime behavior.